### PR TITLE
Inject object into data passed by hte() to service endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,11 @@ function hte (client, service, method, datas) {
   return function (req, res) {
     var data = {}
     datas.forEach(function (d) {
+      if (typeof d === 'object') {
+        merge(data, d)
+        return
+      }
+
       var v = req[d]
       if (typeof v !== 'object' && !Array.isArray(v)) {
         data[d] = v

--- a/test/index.js
+++ b/test/index.js
@@ -116,6 +116,29 @@ describe('HT Express', function () {
       .end()
   })
 
+  it('should pull object data if specified', function (done) {
+    var client = getClientWithServices({ s1: { m1: function (data, callback) {
+      assert.deepEqual(data, {
+        hello: 'world',
+        fruit: 'banana'
+      })
+      callback()
+    } } })
+
+    var app = express()
+    app.use(bodyParser.json())
+    app.set('trust proxy', 1)
+    app.post('/', hte(client, 's1', 'm1', [ 'body', { fruit: 'banana' }]))
+
+    request(app)
+      .post('/')
+      .send({
+        hello: 'world'
+      })
+      .expect(200)
+      .end(done)
+  })
+
   it('should pull non-object data from other places if specified', function (done) {
     var client = getClientWithServices({ s1: { m1: function (data, callback) {
       assert.deepEqual(data, {

--- a/test/index.js
+++ b/test/index.js
@@ -128,7 +128,7 @@ describe('HT Express', function () {
     var app = express()
     app.use(bodyParser.json())
     app.set('trust proxy', 1)
-    app.post('/', hte(client, 's1', 'm1', [ 'body', { fruit: 'banana' }]))
+    app.post('/', hte(client, 's1', 'm1', [ 'body', {fruit: 'banana'} ]))
 
     request(app)
       .post('/')


### PR DESCRIPTION
Route definitions can insert objects with additional parameters which are passed into the service endpoint and are recognized by the schema
