### PR TITLE
Adds stringified cookie object to data

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,12 @@ function hte (client, service, method, datas) {
   return function (req, res) {
     var data = {}
     datas.forEach(function (d) {
+      if (d === 'cookies') {
+        // Cookies are stringified and added to data
+        data['cookies'] = JSON.stringify(req.cookies)
+        return
+      }
+
       if (typeof d === 'object') {
         merge(data, d)
         return

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ function hte (client, service, method, datas) {
     datas.forEach(function (d) {
       if (d === 'cookies') {
         // Cookies are stringified and added to data
-        data['cookies'] = JSON.stringify(req.cookies)
+        data.cookies = JSON.stringify(req.cookies)
         return
       }
 


### PR DESCRIPTION
This is that change discussed earlier - just for cookies so far.  It's cludgy, but will only add overhead if the call to `hte()` includes `cookies` in the array of data sources
